### PR TITLE
Restore functionality of "Following Channels"

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.python.twitch" name="python-twitch for Kodi" version="3.0.1" provider-name="anxdpanic, A Talented Community">
+<addon id="script.module.python.twitch" name="python-twitch for Kodi" version="3.0.2" provider-name="anxdpanic, A Talented Community">
     <requires>
         <import addon="xbmc.python" version="3.0.1"/>
         <import addon="script.module.six" version="1.11.0"/>
@@ -9,8 +9,7 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <news>
-[fix] oauth queries
-[lang] updated translations from Weblate
+[fix] Following Channels
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/resources/lib/twitch/api/helix/users.py
+++ b/resources/lib/twitch/api/helix/users.py
@@ -31,12 +31,10 @@ def get_users(user_id=list(), user_login=list(), use_app_token=False):
 
 # required scope: none
 @query
-def get_follows(from_id='', to_id='', after='MA==', before='MA==', first=20, use_app_token=False):
-    q = Qry('users/follows', use_app_token=use_app_token)
-    q.add_param(keys.FROM_ID, from_id, '')
-    q.add_param(keys.TO_ID, to_id, '')
+def get_follows(user_id='', after='MA==', first=20, use_app_token=False):
+    q = Qry('channels/followed', use_app_token=use_app_token)
+    q.add_param(keys.USER_ID, user_id, '')
     q.add_param(keys.AFTER, Cursor.validate(after), 'MA==')
-    q.add_param(keys.BEFORE, Cursor.validate(before), 'MA==')
     q.add_param(keys.FIRST, IntRange(1, 100).validate(first), 20)
 
     return q


### PR DESCRIPTION
Old API endpoint used for Following Channels (not live!) was apparently deprecated recently, maybe related to [this announcement](https://discuss.dev.twitch.tv/t/legacy-follows-api-and-eventsub-shutdown-timeline-updated/46769)? Can't find any explicit mention of the old users/follows endpoint though.
Anyways, bug report here: https://github.com/anxdpanic/plugin.video.twitch/issues/684

[New endpoint](https://dev.twitch.tv/docs/api/reference/#get-followed-channels) works very similarly, only minor changes required.

Needs change in  plugin.video.twitch as well